### PR TITLE
Add document column filtering and CSV export functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ BOARD_ID=your_board_id_here
 
 # monday Doc のカラムID。指定しない場合は、ボードの最初の monday Doc カラムを使用する。
 MONDAY_DOC_COLUMN_ID=your_column_id_here
+
+# アイテムのページサイズ。デフォルトは 100。
+ITEMS_PAGE_LIMIT=100

--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ MONDAY_LOGIN_URL="https://auth.monday.com/auth/login_monday"
 API_TOKEN=your_api_token_here
 API_URL=https://api.monday.com/v2
 BOARD_ID=your_board_id_here
+
+# monday Doc のカラムID。指定しない場合は、ボードの最初の monday Doc カラムを使用する。
+MONDAY_DOC_COLUMN_ID=your_column_id_here

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ src/cookies.json
 
 # dist
 dist/
+
+# output
+output.csv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   "editor.codeActionsOnSave": {
     "quickfix.biome": "always",
     "source.organizeImports.biome": "always"
+  },
+  "[csv]": {
+    "files.encoding": "shiftjis"
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": []
+    "ignore": ["node_modules", "dist", "build", "coverage"]
   },
   "formatter": {
     "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "dependencies": {
         "axios": "^1.9.0",
+        "csv-stringify": "^6.5.2",
         "dotenv": "^16.5.0",
+        "iconv-lite": "^0.6.3",
         "puppeteer": "^24.7.2"
       },
       "devDependencies": {
@@ -628,6 +630,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/csv-stringify": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.2.tgz",
+      "integrity": "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -1089,6 +1097,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -1418,6 +1438,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
     "axios": "^1.9.0",
+    "csv-stringify": "^6.5.2",
     "dotenv": "^16.5.0",
+    "iconv-lite": "^0.6.3",
     "puppeteer": "^24.7.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import puppeteer from 'puppeteer';
 import { launchChrome } from './lib/launch-chrome';
 import { waitForChrome } from './lib/wait-for-chrome';
+import type { Item, ParsedDocColumnValue } from './types';
 
 dotenv.config();
 
@@ -15,17 +16,6 @@ const API_URL = process.env.API_URL || 'https://api.monday.com/v2';
 const COOKIES_PATH = path.resolve(__dirname, 'cookies.json');
 const BOARD_ID = process.env.BOARD_ID;
 const MONDAY_DOC_COLUMN_ID = process.env.MONDAY_DOC_COLUMN_ID || '';
-
-type Item = {
-  id: string;
-  name: string;
-  column_values: Array<{
-    id: string;
-    type: string;
-    text?: string;
-    value?: string;
-  }>;
-};
 
 const query = `
 query {
@@ -150,7 +140,7 @@ const main = async () => {
 
     if (docColumn?.value) {
       try {
-        const parsed = JSON.parse(docColumn.value);
+        const parsed = JSON.parse(docColumn.value) as ParsedDocColumnValue;
         const files = parsed.files || [];
 
         for (const file of files) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const API_TOKEN = process.env.API_TOKEN || '';
 const API_URL = process.env.API_URL || 'https://api.monday.com/v2';
 const COOKIES_PATH = path.resolve(__dirname, 'cookies.json');
 const BOARD_ID = process.env.BOARD_ID;
+const MONDAY_DOC_COLUMN_ID = process.env.MONDAY_DOC_COLUMN_ID || '';
 
 type Item = {
   id: string;
@@ -139,7 +140,14 @@ const main = async () => {
   const docLinks: { itemName: string; docName: string; url: string }[] = [];
 
   for (const item of items) {
-    const docColumn = item.column_values.find((col) => col.type === 'doc');
+    // Docカラムを取得
+    // NOTE: MONDAY_DOC_COLUMN_IDが指定されている場合、そのカラムのみを対象とする
+    const docColumn = item.column_values.find(
+      (col) =>
+        col.type === 'doc' &&
+        (!MONDAY_DOC_COLUMN_ID || col.id === MONDAY_DOC_COLUMN_ID),
+    );
+
     if (docColumn?.value) {
       try {
         const parsed = JSON.parse(docColumn.value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,13 @@ const API_URL = process.env.API_URL || 'https://api.monday.com/v2';
 const COOKIES_PATH = path.resolve(__dirname, 'cookies.json');
 const BOARD_ID = process.env.BOARD_ID;
 const MONDAY_DOC_COLUMN_ID = process.env.MONDAY_DOC_COLUMN_ID || '';
+const ITEMS_PAGE_LIMIT = process.env.ITEMS_PAGE_LIMIT || 100;
 
 const query = `
 query {
   boards(ids: [${BOARD_ID}]) {
     name
-    items_page(limit: 100) {
+    items_page(limit: ${ITEMS_PAGE_LIMIT}) {
       items {
         id
         name
@@ -33,8 +34,7 @@ query {
       }
     }
   }
-}
-`;
+}`;
 
 const fetchBoardItems = async (): Promise<Item[]> => {
   const response = await axios.post(

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,11 @@ query {
   }
 }`;
 
+/**
+ * ボードのアイテムを取得します。
+ *
+ * @returns {Promise<Item[]>} アイテムの配列
+ */
 const fetchBoardItems = async (): Promise<Item[]> => {
   const response = await axios.post(
     API_URL,
@@ -52,6 +57,9 @@ const fetchBoardItems = async (): Promise<Item[]> => {
   return board.items_page.items;
 };
 
+/**
+ * Cookieを保存します。
+ */
 const saveCookies = async () => {
   // Chromeをデバッグモードで起動
   launchChrome();
@@ -77,6 +85,11 @@ const saveCookies = async () => {
   await browser.close();
 };
 
+/**
+ * Docの内容を読み込みます。
+ *
+ * @param {Array<{ itemName: string; docName: string; url: string }>} docUrls DocのURL配列
+ */
 const readDocContents = async (
   docUrls: { itemName: string; docName: string; url: string }[],
 ) => {
@@ -118,6 +131,9 @@ const readDocContents = async (
   await browser.close();
 };
 
+/**
+ * メイン関数
+ */
 const main = async () => {
   const saveCookiesMode = process.argv.includes('--save-cookies');
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,17 @@
+export interface Item {
+  id: string;
+  name: string;
+  column_values: Array<{
+    id: string;
+    type: string;
+    text?: string;
+    value?: string;
+  }>;
+}
+
+export interface ParsedDocColumnValue {
+  files?: {
+    name: string;
+    linkToFile: string;
+  }[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "ES2020",
     "module": "commonjs",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
Introduce support for filtering document columns using `MONDAY_DOC_COLUMN_ID`, enhance item pagination with `ITEMS_PAGE_LIMIT`, and implement CSV export for document contents. Update TypeScript target and add type definitions for better code clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to export Monday.com Doc contents to a CSV file with Shift_JIS encoding.
  - Introduced configuration options for selecting a specific Doc column and setting the number of items per page.

- **Improvements**
  - Enhanced type safety and documentation for improved code reliability.
  - Updated TypeScript target to support newer JavaScript features.

- **Chores**
  - Updated example environment variables and dependencies.
  - Improved tool configurations and file ignore settings for better development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->